### PR TITLE
Feat: 로그인/회원가입/중복체크 API 매핑 및 토큰 관련 로직 구현

### DIFF
--- a/src/axiosWithToken.ts
+++ b/src/axiosWithToken.ts
@@ -1,0 +1,49 @@
+import axios, { AxiosResponse } from 'axios';
+
+const axiosWithToken = axios.create();
+
+axiosWithToken.defaults.headers.common['Content-Type'] = 'application/json';
+
+axiosWithToken.interceptors.request.use(
+    (config) => {
+        const accessToken = sessionStorage.getItem('accessToken');
+        if (accessToken) {
+            config.headers = {
+                ...config.headers,
+                'Authorization': `Bearer ${accessToken}`,
+            };
+        }
+        return config;
+    },
+    (error) => Promise.reject(error)
+);
+
+
+
+axiosWithToken.interceptors.response.use(
+    (response: AxiosResponse) => response,
+    async (error) => {
+        const originalRequest = error.config;
+
+        if (error.response && error.response.status === 401 && !originalRequest._retry) {
+            originalRequest._retry = true;
+            try {
+                // Refresh 토큰은 쿠키에 자동으로 담겨 전송됨
+                const { response } = await axios.post('/kkumteul/api/auth/refresh');
+
+                const newAccessToken = response.data.response.accessToken;
+                sessionStorage.setItem('accessToken', newAccessToken);
+
+                // 원래 요청에 새 Access 토큰 설정 후 재시도
+                originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
+                return axiosWithToken(originalRequest);
+            } catch (refreshError) {
+                return Promise.reject(refreshError);
+            }
+        }
+        return Promise.reject(error);
+    }
+);
+
+
+export default axiosWithToken;

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -10,20 +10,25 @@ const Login: React.FC = () => {
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
 
-  const handleLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-      const response = await axios.post('/api/users/login', {
-        username,
-        password,
-      });
-      localStorage.setItem('accessToken', response.data.accessToken);
-      navigate('/');
-    } catch (error) {
-      console.error('Login failed', error);
-      alert('로그인 실패');
-    }
-  };
+    const handleLogin = async (e: React.FormEvent) => {
+        e.preventDefault();
+        try {
+            const response = await axios.post('/kkumteul/api/auth/login', {
+                username,
+                password,
+            });
+
+            const accessToken = response.headers['authorization']?.split(' ')[1];
+            if (accessToken) {
+                sessionStorage.setItem('accessToken', accessToken);
+            }
+
+            navigate('/');
+        } catch (error) {
+            console.error('Login failed', error);
+            alert('로그인 실패');
+        }
+    };
 
   return (
     <Container color='#FDDC69'>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -96,8 +96,16 @@ const Index = () => {
     });
   };
 
-  const handleLogout = () => {
-    console.log('로그아웃');
+  const handleLogout = async () => {
+    try {
+      await axios.post('/kkumteul/api/auth/logout');
+      sessionStorage.removeItem('accessToken');
+      alert("로그아웃 되었습니다.");
+      navigate('/login');
+    } catch (error) {
+      console.error('로그아웃 실패:', error);
+      alert('로그아웃에 실패했습니다.');
+    }
   };
 
   const handleDeleteAccount = async () => {

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -1,188 +1,197 @@
-import React, { useState } from 'react';
+import React, {useState} from 'react';
 import axios from 'axios';
-import { useNavigate } from 'react-router-dom';
-import { Container, Button, Input } from '../../styles/globalStyles';
+import {useNavigate} from 'react-router-dom';
+import {Container, Button, Input} from '../../styles/globalStyles';
 import Header from '../../components/layout/Header';
 import styled from 'styled-components';
 
 const SignUp: React.FC = () => {
-  const [formData, setFormData] = useState({
-    username: '',
-    password: '',
-    passwordConfirm: '',
-    name: '',
-    nickname: '',
-    phone: '',
-    birthdate: ''
-  });
-  const navigate = useNavigate();
+    const [formData, setFormData] = useState({
+        username: '',
+        password: '',
+        passwordConfirm: '',
+        name: '',
+        nickname: '',
+        phone: '',
+        birth: ''
+    });
+    const navigate = useNavigate();
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData({ ...formData, [e.target.name]: e.target.value });
-  };
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setFormData({...formData, [e.target.name]: e.target.value});
+    };
 
-  const handleSignUp = async (e: React.FormEvent) => {
-      e.preventDefault();
-      if (formData.password !== formData.passwordConfirm) {
-        alert('비밀번호가 일치하지 않습니다.');
-        return;
-      }
-      try {
-        const response = await axios.post('/api/users/register', formData);
-        alert('회원가입에 성공하였습니다.');
-        navigate('/login');
-      } catch (error) {
-        console.error('회원가입에 실패하였습니다.', error);
-        alert('회원가입에 실패하였습니다.');
-      }
-  };
+    const handleSignUp = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (formData.password !== formData.passwordConfirm) {
+            alert('비밀번호가 일치하지 않습니다.');
+            return;
+        }
+        try {
+            await axios.post('/kkumteul/api/users/register', formData);
+            alert('회원가입에 성공하였습니다.');
+            navigate('/login');
+        } catch (error) {
+            console.error('회원가입에 실패하였습니다.', error);
+            alert('회원가입에 실패하였습니다.');
+        }
+    };
 
-  const handleDuplicateCheck = (field: string) => {
-    alert(`${field} 중복 확인이 필요합니다`);
-  };
+    const handleDuplicateCheck = async (field: string) => {
+        try {
+            let apiUrl = '';
+            if (field === '아이디') {
+                apiUrl = `/kkumteul/api/users/duplicate/username/${formData.username}`;
+            } else if (field === '닉네임') {
+                apiUrl = `/kkumteul/api/users/duplicate/nickname/${formData.nickname}`;
+            }
 
-  return (
-    <Container color='#FDDC69'>
-      <Header textcolor="#000000" color="#FDDC69" nextBtnImageUrl="/assets/home.svg" title="회원가입" nextPage="/" />
-      <CharacterWrapper>
-        <CharacterImage src="/assets/kkumteul_character.png" alt="character" />
-      </CharacterWrapper>
-      <ContentContainer>
-        <Form onSubmit={handleSignUp}>
-          <InputWrapper>
-            <InputStyled
-              color='#FFCB05'
-              placeholder="아이디"
-              name="username"
-              value={formData.username}
-              onChange={handleChange}
-            />
-            <CheckButton type="button" onClick={() => handleDuplicateCheck('아이디')}>중복확인</CheckButton>
-          </InputWrapper>
-            
-          <InputStyled
-            color='#FFCB05'
-            placeholder="비밀번호"
-            name="password"
-            type="password"
-            value={formData.password}
-            onChange={handleChange}
-            />
-            <InputStyled
-              color='#FFCB05'
-              placeholder="비밀번호 확인"
-              name="passwordConfirm"
-              type="password"
-              value={formData.passwordConfirm}
-              onChange={handleChange}
-            />
-            <InputStyled
-            color='#FFCB05'
-            placeholder="이름"
-            name="name"
-            value={formData.name}
-            onChange={handleChange}
-            />
+            const response = await axios.get(apiUrl);
+            if (response.data.response === true) {
+                alert(`${field}가 이미 사용 중입니다.`);
+            } else {
+                alert(`${field}를 사용하실 수 있습니다.`);
+            }
+        } catch (error) {
+            console.error(`${field} 중복 확인 오류`, error);
+            alert(`${field} 중복 확인에 실패하였습니다.`);
+        }
+    };
 
-            <InputWrapper>
-              <InputStyled
-                  color='#FFCB05'
-                  placeholder="닉네임"
-                  name="nickname"
-                  value={formData.nickname}
-                  onChange={handleChange}
-                />
-              <CheckButton type="button" onClick={() => handleDuplicateCheck('닉네임')}>중복확인</CheckButton>
-            </InputWrapper>
-            <InputStyled
-              color='#FFCB05'
-              placeholder="전화번호"
-              name="phone"
-              value={formData.phone}
-              onChange={handleChange}
-            />
-            <InputStyled
-              color='#FFCB05'
-              placeholder="생년월일 ex)980905"
-              name="birthdate"
-              value={formData.birthdate}
-              onChange={handleChange}
-            />
-            <SignUpButton type="submit">회원가입</SignUpButton>
-          </Form>
-      </ContentContainer>
-    </Container>
-  );
+    return (
+        <Container color='#FDDC69'>
+            <Header textcolor="#000000" color="#FDDC69" nextBtnImageUrl="/assets/home.svg" title="회원가입" nextPage="/"/>
+            <CharacterWrapper>
+                <CharacterImage src="/assets/kkumteul_character.png" alt="character"/>
+            </CharacterWrapper>
+            <ContentContainer>
+                <Form onSubmit={handleSignUp}>
+                    <InputWrapper>
+                        <InputStyled
+                            color='#FFCB05'
+                            placeholder="아이디"
+                            name="username"
+                            value={formData.username}
+                            onChange={handleChange}
+                        />
+                        <CheckButton type="button" onClick={() => handleDuplicateCheck('아이디')}>중복확인</CheckButton>
+                    </InputWrapper>
+
+                    <InputStyled
+                        color='#FFCB05'
+                        placeholder="비밀번호"
+                        name="password"
+                        type="password"
+                        value={formData.password}
+                        onChange={handleChange}
+                    />
+                    <InputStyled
+                        color='#FFCB05'
+                        placeholder="비밀번호 확인"
+                        name="passwordConfirm"
+                        type="password"
+                        value={formData.passwordConfirm}
+                        onChange={handleChange}
+                    />
+                    <InputStyled
+                        color='#FFCB05'
+                        placeholder="이름"
+                        name="name"
+                        value={formData.name}
+                        onChange={handleChange}
+                    />
+
+                    <InputWrapper>
+                        <InputStyled
+                            color='#FFCB05'
+                            placeholder="닉네임"
+                            name="nickname"
+                            value={formData.nickname}
+                            onChange={handleChange}
+                        />
+                        <CheckButton type="button" onClick={() => handleDuplicateCheck('닉네임')}>중복확인</CheckButton>
+                    </InputWrapper>
+                    <InputStyled
+                        color='#FFCB05'
+                        placeholder="전화번호"
+                        name="phone"
+                        value={formData.phone}
+                        onChange={handleChange}
+                    />
+                    <InputStyled
+                        color='#FFCB05'
+                        placeholder="생년월일 ex)980905"
+                        name="birth"
+                        value={formData.birth}
+                        onChange={handleChange}
+                    />
+                    <SignUpButton type="submit">회원가입</SignUpButton>
+                </Form>
+            </ContentContainer>
+        </Container>
+    );
 };
 
 export default SignUp;
 
 // 스타일 컴포넌트
-// const FixedHeader = styled(Header)`
-//     position: fixed;
-//     top: 0;
-//     width: 100%;
-//     z-index: 100;
-//     font-size: 32px;
-// `;
-
 const CharacterWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: 40px 0 0 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 40px 0 0 0;
 `;
 
 const CharacterImage = styled.img`
-  width: 100px;
-  height: 100px;
+    width: 100px;
+    height: 100px;
 `;
 
 const ContentContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  margin: 80px;
-  width: 76%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    margin: 80px;
+    width: 76%;
 `;
 
 const Form = styled.form`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    margin: 0 auto;
 `;
 
 const InputStyled = styled(Input)`
-  width: 100%;
-  max-width: 550px;
-  height: 55px;
-  margin-bottom: 12px;
-  border-radius: 12px;
+    width: 100%;
+    max-width: 550px;
+    height: 55px;
+    margin-bottom: 12px;
+    border-radius: 12px;
 `;
 
 const SignUpButton = styled(Button)`
-  width: 100%;
-  background-color: #FFCB05;
-  color: #ffffff;
-  margin-top: 40px;
+    width: 100%;
+    background-color: #FFCB05;
+    color: #ffffff;
+    margin-top: 40px;
 `;
 
 const InputWrapper = styled.div`
-  display: flex;
-  width: 100%;
-  max-width: 550px;
-  margin-bottom: 12px;
+    display: flex;
+    width: 100%;
+    max-width: 550px;
+    margin-bottom: 12px;
 `;
 
 const CheckButton = styled(Button)`
-  width: 40%;
-  height: 55px;
-  background-color: #FFCB05;
-  color: white;
-  margin-left: 10px;
-  border-radius: 12px;
-  font-size: 14px;
+    width: 40%;
+    height: 55px;
+    background-color: #FFCB05;
+    color: white;
+    margin-left: 10px;
+    border-radius: 12px;
+    font-size: 14px;
 `;

--- a/src/pages/Survey/index.tsx
+++ b/src/pages/Survey/index.tsx
@@ -13,6 +13,7 @@ import ProgressLine from '../../components/survey/ProgressLine';
 import PrevButton from '../../components/survey/PrevButton';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import axiosWithToken from "../../axiosWithToken.ts";
 
 const Index = () => {
   const navigate = useNavigate();
@@ -58,7 +59,7 @@ const Index = () => {
         favoriteTopics: selectedKeywords,
       };
 
-      const response = await axios.post('/kkumteul/api/survey', surveyData);
+      const response = await axiosWithToken.post('/kkumteul/api/survey', surveyData);
       if (response.status === 200) {
         navigate('/survey/result', { state: response.data });
       }


### PR DESCRIPTION
## ✅ 연관된 이슈

> ex) #59 

## ✏️ 작업 내용

로그인 / 회원가입 / 중복확인 API 매핑
 
모든 요청 시 헤더에 Access 토큰을 담아주는 로직
 
로그인 시 받은 Access 토큰을 클라이언트 sessionStorage에 저장하는 로직
 
로그아웃 시 sessionStorage에 있는 Access 토큰 삭제하는 로직
 
Access 토큰 만료 시 인터셉터에서 refresh API 호출할 수 있도록 하는 로직

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
